### PR TITLE
FIX: Ridge regressor - L2 regularization formula on notebook 4

### DIFF
--- a/content/python_files/04_linear_model_regularization.py
+++ b/content/python_files/04_linear_model_regularization.py
@@ -90,7 +90,7 @@ plt.show()
 # We saw that coefficients can grow arbitrarily large when features correlate.
 #
 # $$
-# loss = (y - X \beta)^2 + \alpha \|\beta\|_2
+# loss = (y - X \beta)^2 + \alpha \|\beta\|_2^2
 # $$
 #
 # L2 regularization forces weights toward zero. The parameter $\alpha$ controls

--- a/content/python_files/04_linear_model_regularization.py
+++ b/content/python_files/04_linear_model_regularization.py
@@ -132,7 +132,7 @@ plt.show()
 # L1 provides another regularization type. It follows this formula:
 #
 # $$
-# loss = \frac{1} {2 n\_samples} ||y - X\beta||^2_2 + \alpha  ||\beta||_1
+# loss = ||y - X\beta||^2_2 + \alpha  ||\beta||_1
 # $$
 #
 # Scikit-learn implements this as the Lasso regressor.

--- a/content/python_files/04_linear_model_regularization.py
+++ b/content/python_files/04_linear_model_regularization.py
@@ -132,7 +132,7 @@ plt.show()
 # L1 provides another regularization type. It follows this formula:
 #
 # $$
-# loss = (y - X \beta)^2 + \alpha \|\beta\|_1
+# loss = \frac{1} {2 n\_samples} ||y - X\beta||^2_2 + \alpha  ||\beta||_1
 # $$
 #
 # Scikit-learn implements this as the Lasso regressor.

--- a/content/python_files/04_linear_model_regularization.py
+++ b/content/python_files/04_linear_model_regularization.py
@@ -90,7 +90,7 @@ plt.show()
 # We saw that coefficients can grow arbitrarily large when features correlate.
 #
 # $$
-# loss = (y - X \beta)^2 + \alpha \|\beta\|_2^2
+# loss = ||y - X \beta||_2^2 + \alpha \|\beta\|_2^2
 # $$
 #
 # L2 regularization forces weights toward zero. The parameter $\alpha$ controls


### PR DESCRIPTION
The formula in the notebook seems incorrect.
Comparing to https://scikit-learn.org/stable/auto_examples/linear_model/plot_ridge_coeffs.html 